### PR TITLE
Make field parameter for coalesce nullable

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -9,6 +9,6 @@ declare type Enum<T> = {
 
 declare module.exports: {
   make: (dfn: EnumDefinition<*>) => Enum<*>,
-  coalesce: (obj: Enum<*>, field: $Enum<*>) => ?$Enum<*>,
+  coalesce: (obj: Enum<*>, field: ?$Enum<*>) => ?$Enum<*>,
   enforce: (obj: Enum<*>, field: $Enum<*>) => $Enum<*>,
 };

--- a/interfaces/Enumjs.js.flow
+++ b/interfaces/Enumjs.js.flow
@@ -10,7 +10,7 @@ declare type Enum<T> = {
 declare module 'Enumjs' {
   declare module.exports: {
     make: (dfn: EnumDefinition<*>) => Enum<*>,
-    coalesce: (obj: Enum<*>, field: $Enum<*>) => ?$Enum<*>,
+    coalesce: (obj: Enum<*>, field: ?$Enum<*>) => ?$Enum<*>,
     enforce: (obj: Enum<*>, field: $Enum<*>) => $Enum<*>,
   };
 };


### PR DESCRIPTION
Hi! Nice package, exactly what I was looking for.

In my opinion, it makes sense to make the second parameter for `coalesce` nullable as its return type is nullable, anyway. For example, matching user provided, optional input (e.g., from a config file) against an enum would only require a simple coalesce call instead of checking whether the property is actually non-null **and** a valid enum type (logically, the second condition is only true if the first condition is met, anyway).

So, I have to write code such as `const choosenEnum = coalesce(myEnum, userProvidedOptionalValue || myEnum.default) || myEnum.default` instead of `const choosenEnum = coalesce(myEnum, userProvidedOptionalValue) || myEnum.default`

Do you agree? :)

By the way, please consider releasing a new version to npm. The npm page still shows the readme without the capitalization warning (enumjs vs Enumjs). Also the packaged flowtypes don't work. I ran into both issues and spent unnecessary time fixing them :)